### PR TITLE
Remove unnecessary horizontal padding on select element

### DIFF
--- a/web/css/vendor/magento-ui/_forms.scss
+++ b/web/css/vendor/magento-ui/_forms.scss
@@ -60,7 +60,7 @@ $form-element-validation__border-error: lighten($form-validation-note__color-err
     $_focus-font-style          : $_font-style;
 
     @if $_type == "select" {
-        $_padding               : $indent__s 4px;
+        $_padding               : 4px;
         $_placeholder-color     : inherit;
         $_placeholder-font-style: inherit;
     }


### PR DESCRIPTION
Removed $indent__s variable from padding for select elements in lib-form-element-input mixin which caused display issues with selects in FF.
