### PR TITLE
Fix responsive tables display in mobile view

### DIFF
--- a/Magento_Checkout/css/source/module/_cart.scss
+++ b/Magento_Checkout/css/source/module/_cart.scss
@@ -352,13 +352,15 @@ $cart-item-cell-padding-top: 20px;
     }
 }
 
-.cart.table-wrapper,
-.order-items.table-wrapper {
-    .col.msrp,
-    .col.price,
-    .col.qty,
-    .col.subtotal {
-        text-align: right;
+@include min-screen($screen__m) {
+    .cart.table-wrapper,
+    .order-items.table-wrapper {
+        .col.msrp,
+        .col.price,
+        .col.qty,
+        .col.subtotal {
+            text-align: right;
+        }
     }
 }
 

--- a/web/css/vendor/magento-ui/_tables.scss
+++ b/web/css/vendor/magento-ui/_tables.scss
@@ -343,9 +343,9 @@
 
 @mixin lib-table-responsive(
     $_table-background-color-responsive   : $table__background-color,
-    $_table-th-background-color-responsive: inherit,
-    $_reset-table-striped                 : inherit,
-    $_reset-table-hover                   : inherit,
+    $_table-th-background-color-responsive: $table-responsive-th__background-color,
+    $_reset-table-striped                 : false,
+    $_reset-table-hover                   : false,
     $_table-responsive-cell-padding       : $indent__xs 0
 ) {
     @if $_reset-table-striped == true {


### PR DESCRIPTION
We've noticed this issue with My Orders table in my account but I suspect it's common for all responsive tables aside from cart table: https://www.evernote.com/shard/s55/sh/e708ca4c-994d-427d-b18c-707f65f74403/ccabf141548d088ac6d3508dbf17f444

Fixed: https://www.evernote.com/shard/s55/sh/93bcbc7f-ddb7-42c7-a7cb-9121823c3118/53e431fd8522fab5870f0dd4c83a946a
