### PR TITLE
Fix caret position in validation error message

### DIFF
--- a/web/css/vendor/magento-ui/_forms.scss
+++ b/web/css/vendor/magento-ui/_forms.scss
@@ -357,7 +357,7 @@ $form-element-validation__border-error: lighten($form-validation-note__color-err
     }
 
     div.mage-error[generated] {
-        @include lib-form-validation-note();
+        @include lib-form-validation-note($_note-icon-font-margin:0);
     }
 
     input[type="button"],

--- a/web/css/vendor/magento-ui/_forms.scss
+++ b/web/css/vendor/magento-ui/_forms.scss
@@ -357,7 +357,7 @@ $form-element-validation__border-error: lighten($form-validation-note__color-err
     }
 
     div.mage-error[generated] {
-        @include lib-form-validation-note($_note-icon-font-margin:0);
+        @include lib-form-validation-note($_note-icon-font-margin: 0);
     }
 
     input[type="button"],


### PR DESCRIPTION
Fixed misaligned caret in validation error message: https://www.evernote.com/shard/s55/sh/429f5066-c13b-451f-b98c-91d0c47e31b1/1c61538364fd22a706030d010c8d3af6
