### PR TITLE
Remove "or" from top links

### DIFF
--- a/Magento_Theme/css/source/_module.scss
+++ b/Magento_Theme/css/source/_module.scss
@@ -573,14 +573,6 @@ body {
                     }
                 }
 
-                & > .authorization-link {
-                    &:after {
-                        content: attr(data-label);
-                        display: inline-block;
-                        margin: 0 -$indent__xs 0 $indent__xs;
-                    }
-                }
-
                 & > .customer-welcome + .authorization-link {
                     display: none;
                 }


### PR DESCRIPTION
This css rule seems to have been imported from Luma. It's redundant here since "Create and Account" precedes "Sign In" in the blank theme.  
