### PR TITLE
Fix default width value in lib_button()

### DIFF
--- a/web/css/vendor/magento-ui/_buttons.scss
+++ b/web/css/vendor/magento-ui/_buttons.scss
@@ -61,7 +61,7 @@ $button__padding__s: $indent__xs 8px;
     $_button-cursor                     : pointer,
     $_button-display                    : inline-block,
     $_button-disabled-opacity           : 0.5,
-    $_button-width                      : inherit,
+    $_button-width                      : auto,
     $_button-margin                     : 0,
     $_button-padding                    : 7px 15px,
     $_button-color                      : $primary__color,


### PR DESCRIPTION
Default width value in lib-button() mixin is set as inherit. It leads to unexpected results. 
Example: https://www.evernote.com/shard/s55/sh/6a5e90ac-18a3-4af8-9a6e-c61f9e8c96f4/1fc50dbec428821e2766e184c035ce32

This fix changes that value to **auto**. 
Fixed: https://www.evernote.com/shard/s55/sh/e620457e-b896-44e5-af4f-a6e3b14c96ad/e935fc5b016b3b767951e123bedb9bb2
