### PR TITLE
Fix order of params in lib-form-field-type

### DIFF
--- a/web/css/vendor/magento-ui/_forms.scss
+++ b/web/css/vendor/magento-ui/_forms.scss
@@ -610,7 +610,7 @@ $form-element-validation__border-error: lighten($form-validation-note__color-err
     $_type-inline-label-padding    : 6px 15px 0 0,
     $_type-inline-label-align      : right,
     $_type-inline-label-width      : 25.8%,
-    $_type-inline-control-width    : 25.8%,
+    $_type-inline-control-width    : 74.2%,
 
     $_type-block-margin            : 0 0 $indent__base,
     $_type-block-label-margin      : 0 0 $indent__xs,
@@ -806,18 +806,19 @@ $form-element-validation__border-error: lighten($form-validation-note__color-err
     $_type,
 
     $_type-inline-margin       : 0 0 $indent__base,
-    $_type-inline-label-width  : 25.8%,
     $_type-inline-label-margin : inherit,
     $_type-inline-label-padding: 6px 15px 0 0,
     $_type-inline-label-align  : right,
+    $_type-inline-label-width  : 25.8%,
     $_type-inline-control-width: 74.2%,
+    $_vertical-indent          : $indent__base / 2,
 
     $_type-block-margin        : $indent__base,
     $_type-block-label-margin  : 0 0 $indent__xs,
     $_type-block-label-padding : inherit,
-    $_type-block-label-align   : inherit,
+    $_type-block-label-align   : inherit
 
-    $_vertical-indent          : $indent__base / 2
+
 ) {
     @if $_type == "inline" {
         @include _lib-form-field-type-inline(


### PR DESCRIPTION
This fix is related to issue #33. The reason for the unexpected behavior was a wrong order of params in the `lib-form-field-type` mixin. 

We've also noticed that the default value for `$_type` in `lib-form-field()` is set to _block_, while in the Blank theme it's set to _inline_ resulting in [different display of form labels](https://www.evernote.com/shard/s55/sh/236a2e44-e547-4d14-bfb4-9d51cd3d6791/1753ce439c81bf12bb83832b119b8a58). We were just wondering if this was intentional or should that be updated.
