### PR TITLE
Add missing selectors for responsive buttons

### DIFF
--- a/Magento_Bundle/css/source/_module.scss
+++ b/Magento_Bundle/css/source/_module.scss
@@ -11,8 +11,7 @@
     margin: 0 0 $indent__l;
     .action.primary.customize {
         @extend .abs-button-l;
-        // TO DO - The selector ".abs-button-responsive" was not found.
-        // @extend .abs-button-responsive !optional;
+        @extend .abs-button-responsive;
     }
 }
 
@@ -131,8 +130,7 @@
 
             .action.primary {
                 @extend .abs-button-l;
-                // TO DO - The selector ".abs-button-responsive" was not found.
-                // @extend .abs-button-responsive !optional;
+                @extend .abs-button-responsive;
             }
         }
 

--- a/Magento_Catalog/css/source/_module.scss
+++ b/Magento_Catalog/css/source/_module.scss
@@ -394,8 +394,7 @@ $product-h1-margin-bottom-desktop: $indent__s + $indent__xs;
     .product-info-main .box-tocart {
         .actions {
             .action.tocart {
-                // TO DO - The selector ".abs-button-responsive-smaller" was not found.
-                // @extend .abs-button-responsive-smaller !optional;
+                @extend .abs-button-responsive-smaller;
             }
         }
     }

--- a/web/css/blocks/_actions-toolbar.scss
+++ b/web/css/blocks/_actions-toolbar.scss
@@ -12,8 +12,7 @@
     & > .secondary {
         text-align: center;
         .action {
-            // TO DO - The selector ".abs-button-responsive" was not found.
-            // @extend .abs-button-responsive !optional;
+            @extend .abs-button-responsive;
             margin-bottom: $indent__s;
 
             &:last-child {

--- a/web/css/blocks/_extends.scss
+++ b/web/css/blocks/_extends.scss
@@ -67,6 +67,26 @@
 }
 
 //
+//  Button reset width, floats, margins
+//  ---------------------------------------------
+
+.abs-button-responsive {
+    @include lib-button-responsive();
+}
+
+@include min-screen($screen__m) {
+    .abs-button-desktop {
+        width: auto;
+    }
+}
+
+@include max-screen($screen__m) {
+    .abs-button-responsive-smaller {
+        @include lib-button-responsive();
+    }
+}
+
+//
 //  Action addto
 //  ---------------------------------------------
 .abs-action-addto-product {

--- a/web/css/styles.scss
+++ b/web/css/styles.scss
@@ -31,8 +31,6 @@
 @import 'blocks/price';
 @import 'blocks/gallery';
 
-// Theme extends
-
 // Components styles (modal/sliding panel)
 @import 'blocks/components/modals'; // from lib
 @import 'blocks/components/modals_extend'; // local

--- a/web/css/styles.scss
+++ b/web/css/styles.scss
@@ -32,7 +32,6 @@
 @import 'blocks/gallery';
 
 // Theme extends
-@import 'blocks/extends';
 
 // Components styles (modal/sliding panel)
 @import 'blocks/components/modals'; // from lib


### PR DESCRIPTION
Added:
- .abs-button-responsive 
- .abs-button-desktop 
- .abs-button-responsive-smaller 

Removed duplicate @import 'blocks/extends'

Examples of issues resolved with this fix :
https://www.evernote.com/shard/s55/sh/cc00411a-7553-416d-8adf-c5a039f53921/a4ddcb6d0e55fdf51a70367198176a68
https://www.evernote.com/shard/s55/sh/fcb8d2fc-cffa-45b5-b3d4-9c8777a40847/f4da3057bacef988c3d9de2eb06f7adf
