### PR TITLE
Fix padding for .abs-reset-image-wrapper

### DIFF
--- a/web/css/blocks/_extends.scss
+++ b/web/css/blocks/_extends.scss
@@ -152,7 +152,7 @@
 //  ---------------------------------------------
 .abs-reset-image-wrapper {
     height: auto;
-    padding: 0;
+    padding: 0 !important;
 
     .product-image-photo {
         position: static;


### PR DESCRIPTION
Missing `!important` flag caused unnecessary padding added by js. 

See examples below:
https://www.evernote.com/shard/s55/sh/010646b1-def6-43e7-ac00-29f2774cdb2b/a6c4e361932ea1ad30541e456c63a175
https://www.evernote.com/shard/s55/sh/6f4f7fe1-30cf-4b70-b577-3fd8cba4e19a/fa88d0a43e2426ca1ca95e67bca4f03c

Solution ported from Blank: https://github.com/magento/magento2/blob/develop/app/design/frontend/Magento/blank/web/css/source/_extends.less#L128-#L137
