### PR TITLE
Restore tables styling from Blank

### DIFF
--- a/web/css/blocks/_tables.scss
+++ b/web/css/blocks/_tables.scss
@@ -14,27 +14,29 @@ table {
 }
 
 .table {
-    tfoot {
-        background: $sidebar__background-color;
+    &:not(.cart) {
+        &:not(.totals) {
+            @include lib-table-bordered(
+                $_table_type: light,
+                $_table_border-width: $table__border-width
+            );
 
-        & > tr {
-            &:first-child {
-                th,
-                td {
-                    border-top: $table__border-width $table__border-style $table__border-color;
-                    padding-top: $indent__base;
+            tfoot {
+                > tr {
+                    &:first-child {
+                        th,
+                        td {
+                            border-top: $table__border-width $table__border-style $table__border-color;
+                            padding-top: $indent__base;
+                        }
+                    }
+                }
+
+                .mark {
+                    font-weight: $font-weight__regular;
+                    text-align: right;
                 }
             }
-        }
-
-        th,
-        td {
-            border: 0;
-        }
-
-        .mark {
-            font-weight: $font-weight__regular;
-            text-align: right;
         }
     }
 }
@@ -43,7 +45,6 @@ table {
 //  _____________________________________________
 @include max-screen($screen__s) {
     .table-wrapper {
-        border-top: $table__border-width $table__border-style $table__border-color;
         @include lib-table-overflow();
         position: relative; // To hide unnecessary horizontal scrollbar in Safari
 
@@ -142,11 +143,3 @@ table {
     }
 }
 
-//
-//  Desktop
-//  _____________________________________________
-@include min-screen($screen__s) {
-    .table {
-        @include lib-table-bordered( $_table_type: horizontal_body );
-    }
-}


### PR DESCRIPTION
Some tables-related rules were ported from Luma resulting in inconsistent styling. We restored the default Blank styles.

Blank: https://www.evernote.com/shard/s55/sh/b4070310-4cb2-471e-a919-fca63a1ca623/e919e9a28432bd5bae8f43d123b30ea2

Sass (before fix): https://www.evernote.com/shard/s55/sh/a44c4905-13d0-41bf-94e5-4fe3a4ccc89a/c0b5b4384f9c5f936865a6df9f1bf198
