### PR TITLE
Make Package installable in 2.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
     "type": "magento2-theme",
     "require": {
       "php": "~5.5.0|~5.6.0|~7.0.0",
-      "magento/framework": "100.0.*"
+      "magento/framework": "^100.0.0"
     },
     "autoload": {
         "files": [


### PR DESCRIPTION
Magento 2.1 requires magento-framework 100.1.0-rc1 which is not covered by 100.0.*
The ^ version constraint is designe for semantic versioning and should be used here I think. This will allow any subversion of the 100 Major Version
