### PR TITLE
no menu at 768px

### DIFF
--- a/web/css/blocks/_navigation.scss
+++ b/web/css/blocks/_navigation.scss
@@ -39,7 +39,7 @@
 //  _____________________________________________
 
 $active-nav-indent: 54px;
-@include max-screen($screen__m) {
+@include max-screen($screen__m - 1) {
     .navigation {
         padding: 0;
 


### PR DESCRIPTION
With a window width of 768px ($screen_m) we have no menu. Mobile menu is shown below 768px and desktop above 768px, at 768px both are hidden.
