### PR TITLE
Switch MultipleWishlist popup from margin-left to translateX

### DIFF
--- a/Magento_MultipleWishlist/styles/_module.scss
+++ b/Magento_MultipleWishlist/styles/_module.scss
@@ -373,9 +373,9 @@ $desktop-popup-position-top : 20%;
             bottom: auto;
             top: $desktop-popup-position-top;
             left: $desktop-popup-position-left;
-            margin-left: $desktop-popup-margin-left;
-            width: $desktop-popup-width;
             right: auto;
+            width: $desktop-popup-width;
+            transform: translateX(-$desktop-popup-margin-left);
 
             .field {
                 @include lib-form-field-type-revert($_type: block);


### PR DESCRIPTION
Currently, the margin-left on multiplewishlist is overflowing due to negative margin value. See BUG https://github.com/SnowdogApps/magento2-theme-blank-sass/issues/125

<img width="648" alt="screen shot 2017-01-06 at 3 48 19 pm" src="https://cloud.githubusercontent.com/assets/3484527/21733306/ba58a4ba-d42b-11e6-88c9-92697deded0a.png">

This replaces margin-left with translateX

### If this fix is ultimately approved, it will need to be re-applied once https://github.com/SnowdogApps/magento2-theme-blank-sass/pull/124 merges.