### PR TITLE
Checkout sidebar should have a default length of 4

### DIFF
--- a/styles/_variables.scss
+++ b/styles/_variables.scss
@@ -195,7 +195,7 @@ $checkout-step-title__padding: $indent__s !default;
 $checkout-step-title__border: $border-width__base solid $color-gray80 !default;
 $checkout-step-title__font-size: 26px !default;
 $checkout-step-title__font-weight: $font-weight__light !default;
-$checkout-sidebar__columns: 8 !default;
+$checkout-sidebar__columns: 4 !default;
 $checkout-shipping-address__max-width: 500px !default;
 
 //  Typography


### PR DESCRIPTION
Checkout sidebar should have a default length of 4 instead of 8 like the default that is defined in Magento_Checkout/styles/module/checkout/_sidebar.scss
Otherwise the default of 4 gets overriden and the sidebar has too large width.