### PR TITLE
Added missing selector for required form field

### DIFF
--- a/styles/vendor/magento-ui/_forms.scss
+++ b/styles/vendor/magento-ui/_forms.scss
@@ -947,7 +947,8 @@
     $_line-height: inherit,
     $_margin     : 0 0 0 $indent__xs
 ) {
-    &.required > .label {
+    &.required > .label,
+    &._required > .label {
         &:after {
             content: '*';
             @include lib-typography(


### PR DESCRIPTION
Fixes missing asterisks for required form fields.

Before:
<img width="561" alt="before" src="https://cloud.githubusercontent.com/assets/2178371/25493912/22b8593a-2b78-11e7-8f6e-07efb8942b10.png">
After:
<img width="550" alt="after" src="https://cloud.githubusercontent.com/assets/2178371/25493915/257a8a76-2b78-11e7-8b8e-466ea184960c.png">
