### PR TITLE
Hotfix: incorrect forms variable name

### DIFF
--- a/styles/vendor/magento-ui/_forms.scss
+++ b/styles/vendor/magento-ui/_forms.scss
@@ -644,7 +644,8 @@
     $_type-inline-label-width      : $form-field-type-label-inline__width,
     $_type-inline-control-width    : $form-field-type-control-inline__width,
 
-    $_type-block-margin            : $form-field-type-label-block__margin,
+    $_type-block-margin            : $form-field-type-block__margin,
+
     $_type-block-label-margin      : $form-field-type-label-block__margin,
     $_type-block-label-padding     : $form-field-type-label-block__padding,
     $_type-block-label-align       : $form-field-type-label-block__align,


### PR DESCRIPTION
The variable used for setting form field margins currently uses *label* margins, rather than using the variable specific to fields.