### PR TITLE
Added back comparison rather than assignment change from 0.11.0

### DIFF
--- a/Magento_Checkout/styles/module/_cart.scss
+++ b/Magento_Checkout/styles/module/_cart.scss
@@ -340,7 +340,7 @@
 
         .actions-toolbar {
             .column.main & {
-                @extend .abs-reset-left-margin-desktop;
+                @include abs-reset-left-margin();
                 > .secondary {
                     float: none;
                 }
@@ -398,7 +398,7 @@
 
             .item-actions {
                 .actions-toolbar {
-                    @extend .abs-reset-left-margin-desktop;
+                    @include abs-reset-left-margin();
                     text-align: left;
                 }
             }

--- a/Magento_Checkout/styles/module/checkout/_tooltip.scss
+++ b/Magento_Checkout/styles/module/checkout/_tooltip.scss
@@ -133,7 +133,7 @@ $checkout-tooltip-content-mobile__top           : 30px + $checkout-tooltip-icon-
 @include max-screen($checkout-tooltip-breakpoint__screen-m) {
     .field-tooltip {
         .field-tooltip-content {
-            @extend .abs-checkout-tooltip-content-position-top-mobile;
+            @include abs-checkout-tooltip-content-position-top();
         }
     }
 }

--- a/Magento_Sales/styles/_module.scss
+++ b/Magento_Sales/styles/_module.scss
@@ -251,7 +251,7 @@
         }
 
         .toolbar {
-            @extend .abs-add-clearfix-desktop;
+            @include abs-add-clearfix();
 
             .pages {
                 float: right;
@@ -365,10 +365,10 @@
         .column.main {
             .block:not(.widget) {
                 .block-content {
-                    @extend .abs-add-clearfix-desktop;
+                    @include abs-add-clearfix();
 
                     .box {
-                        @extend .abs-blocks-2columns;
+                        @include abs-blocks-2columns();
                         margin-bottom: $indent__base;
                     }
                 }

--- a/styles/vendor/magento-ui/_loaders.scss
+++ b/styles/vendor/magento-ui/_loaders.scss
@@ -29,7 +29,7 @@
     top: 0;
 
     &:before {
-        @if $_loader-text = true {
+        @if $_loader-text == true {
             @include lib-css(padding, $_loader-text-padding);
             content: attr(data-text);
             text-align: center;

--- a/styles/vendor/magento-ui/_pages.scss
+++ b/styles/vendor/magento-ui/_pages.scss
@@ -310,7 +310,7 @@
     $_pager-reset-spaces,
     $_pager-item-display
 ) {
-    @if $_pager-reset-spaces == true and $_pager-item-display = inline-block {
+    @if $_pager-reset-spaces == true and $_pager-item-display == inline-block {
         @include lib-inline-block-space-container();
         white-space: nowrap;
     }
@@ -322,7 +322,7 @@
     $_pager-font-size,
     $_pager-line-height
 ) {
-    @if $_pager-reset-spaces = true and $_pager-item-display = inline-block {
+    @if $_pager-reset-spaces == true and $_pager-item-display == inline-block {
         @include lib-inline-block-space-item(
             $_font-size   : $_pager-font-size,
             $_line-height : $_pager-line-height


### PR DESCRIPTION
When upgrading from 2.1 to 2.2 noticed that sass doesn't compile anymore due to this change.
Was originally running version 0.11.0 and can see them as https://github.com/SnowdogApps/magento2-theme-blank-sass/blob/0.11.0/styles/vendor/magento-ui/_loaders.scss#L49