### PR TITLE
Remove duplicate reset mixin call #169

### DIFF
--- a/styles/styles.scss
+++ b/styles/styles.scss
@@ -9,7 +9,7 @@
 @import 'variables';
 
 // Reset default styles with magento-reset
-@include lib-magento-reset();
+@import 'blocks/reset';
 
 // Theme blocks
 @import 'blocks/actions-toolbar';
@@ -25,7 +25,6 @@
 @import 'blocks/pages'; // Theme pager
 @import 'blocks/popups';
 @import 'blocks/price';
-@import 'blocks/reset';
 @import 'blocks/sections';
 @import 'blocks/tables';
 @import 'blocks/tooltips';


### PR DESCRIPTION
I have removed the reset mixin and replaced it with the reset file, I've chosen to do this rather than vice versa as it easily allows additional resets to be used after the Magento mixin. But either way will resolve the issue.

I have also moved the reset file import up, as it's imported after other files it can overwrite them. This also brings it closer to core as the reset file is the [first import in the LESS theme](https://github.com/magento/magento2/blob/2.2-develop/app/design/frontend/Magento/blank/web/css/styles-m.less#L16).