### PR TITLE
Add before & after files for easier extensibility

### DIFF
--- a/styles/extends/_after.scss
+++ b/styles/extends/_after.scss
@@ -1,0 +1,1 @@
+// Place your custom changes here

--- a/styles/extends/_before.scss
+++ b/styles/extends/_before.scss
@@ -1,0 +1,1 @@
+// Place your custom changes here

--- a/styles/styles.scss
+++ b/styles/styles.scss
@@ -1,3 +1,5 @@
+@import 'extends/before';
+
 // Mixins
 @import "mixins/media-queries";
 
@@ -79,3 +81,5 @@
 @import '../Magento_Cms/styles/widgets';
 @import '../Magento_MultipleWishlist/styles/widgets';
 @import '../Magento_VersionsCms/styles/widgets';
+
+@import 'extends/after';


### PR DESCRIPTION
I'm sure that everybody makes custom changes to this module and there seems to be some confusion on how to best extend it (Magento Forums). The module should by default offer developers an extensibility option that doesn't break on updates.

I've added two empty files that should take care of most use cases where extending is needed. 

An example on how I use them in my projects:

**extends/_before.scss**
```
@import "before/variables"; // rewrites for default variables & some custom ones
@import "before/foundation"; // foundation framework
```

**extends/_after.scss**
```
@import "after/typography"; // custom fonts
@import "../../MyNamespace_Custom/module"; // my custom module
// My custom changes for Magento_Catalog. If I only have minor changes, 
// then it's a lot more convenient to have them in a separate file as it doesn't 
// cause problems on module updates.
@import "../../Magento_Catalog/common"; 
```

  