### PR TITLE
Fixed magento-ui message icon position

### DIFF
--- a/styles/vendor/magento-ui/_messages.scss
+++ b/styles/vendor/magento-ui/_messages.scss
@@ -245,9 +245,9 @@
     $_message-icon-color,
     $_message-icon-background,
     $_message-icon-top,
-    $_message-icon-left,
+    $_message-icon-right,
     $_message-icon-bottom,
-    $_message-icon-right
+    $_message-icon-left
 ) {
     @include lib-css(padding-left, $message-icon__inner-padding-left);
     position: relative;


### PR DESCRIPTION
The left and right parameters were reversed.