### PR TITLE
Reorganise styles/vendor/magento-ui/_lib Imports #223

### DIFF
--- a/styles/vendor/magento-ui/_lib.scss
+++ b/styles/vendor/magento-ui/_lib.scss
@@ -2,6 +2,7 @@
 //  Global lib
 //  _____________________________________________
 
+@import 'variables';
 @import 'actions-toolbar';
 @import 'breadcrumbs';
 @import 'buttons';
@@ -22,4 +23,3 @@
 @import 'tooltips';
 @import 'typography';
 @import 'utilities';
-@import 'variables';


### PR DESCRIPTION
## Relates To
#223 

## Description
Moved the `variables` import to be the first import statement to resolve excessive layout width reported by @basbold in #223
