### PR TITLE
ADD: missing visually-hidden on label

### DIFF
--- a/Magento_Checkout/styles/module/checkout/_tooltip.scss
+++ b/Magento_Checkout/styles/module/checkout/_tooltip.scss
@@ -48,6 +48,10 @@ $checkout-tooltip-content-mobile__top           : 30px + $checkout-tooltip-icon-
         }
     }
 
+    .label {
+        @include lib-visually-hidden();
+    }
+
     .field-tooltip-action {
         @include lib-icon-font(
             $checkout-tooltip-icon__content,


### PR DESCRIPTION
The visually-hidden style is missing on the tooltip label [-> Magento source](https://github.com/magento/magento2/blob/5a82cc97b89c8bdf16740904827743f6d42f8343/app/design/frontend/Magento/blank/Magento_Checkout/web/css/source/module/checkout/_tooltip.less#L58)