### PR TITLE
FIX: missing fontSizeUnitConvert in email-inline

### DIFF
--- a/styles/email/_email-base-inline.scss
+++ b/styles/email/_email-base-inline.scss
@@ -21,6 +21,11 @@
 //      * universal (*)
 //      * pseudo (a:hover, a:active, a:focus, span:before, span:after, etc)
 
+//
+// Variables
+// _____________________________________________
+
+$font-size-unit-convert: false; // Prevents font-related measurements from being converted to the incompatible rem unit
 
 //
 //  Resets


### PR DESCRIPTION
The email inline styles still use the rem unit.
Which breaks in none web email clients.