### PR TITLE
Remove padding value as per Magento#23170

### DIFF
--- a/styles/vendor/magento-ui/_navigation.scss
+++ b/styles/vendor/magento-ui/_navigation.scss
@@ -354,7 +354,6 @@
                 display: none;
                 left: 0;
                 margin: 0 !important;
-                padding: 0;
                 position: absolute;
                 z-index: 1;
 


### PR DESCRIPTION
Currently, it is not possible to override the `.submenu` padding. This is because the padding value is set twice; once by the value defined and then again to 0. This results in the value not being able to be changed and it is always 0.

Magento Issue: https://github.com/magento/magento2/issues/23170
Magento PR: https://github.com/magento/magento2/pull/25176

This has been fixed in 2.3.4 but not yet in Snowdog.