### PR TITLE
fix column width calculations for listings

### DIFF
--- a/Magento_Catalog/styles/module/_listings.scss
+++ b/Magento_Catalog/styles/module/_listings.scss
@@ -1,4 +1,7 @@
+//
 //  Product Lists
+//  ---------------------------------------------
+
 .products {
     margin: $indent__l 0;
 }
@@ -28,9 +31,6 @@
 
         &-name {
             @extend .abs-product-link;
-            -moz-hyphens: auto;
-            -ms-hyphens: auto;
-            -webkit-hyphens: auto;
             display: block;
             hyphens: auto;
             margin: $indent__xs 0;
@@ -99,7 +99,7 @@
             margin: $indent__s 0 $indent__m;
 
             .price {
-                font-size: 14;
+                font-size: 1.4rem;
                 font-weight: $font-weight__bold;
                 white-space: nowrap;
             }
@@ -116,7 +116,7 @@
         .special-price,
         .minimal-price {
             .price {
-                font-size: 14;
+                font-size: 1.4rem;
                 font-weight: $font-weight__bold;
             }
 
@@ -156,7 +156,7 @@
 
             .price-label {
                 @include lib-css(color, $link__color);
-                font-size: 14;
+                font-size: 1.4rem;
             }
 
             .price {
@@ -188,7 +188,7 @@
 
 .price-container {
     .price {
-        font-size: 14;
+        font-size: 1.4rem;
     }
 
     .price-including-tax + .price-excluding-tax,
@@ -202,7 +202,7 @@
     .weee .price,
     .weee + .price-excluding-tax:before,
     .weee + .price-excluding-tax .price {
-        font-size: 11;
+        font-size: 1.1rem;
     }
 
     .weee {

--- a/Magento_Catalog/styles/module/_listings.scss
+++ b/Magento_Catalog/styles/module/_listings.scss
@@ -1,31 +1,40 @@
-//
 //  Product Lists
-//  _____________________________________________
-
 .products {
     margin: $indent__l 0;
 }
 
 .product {
     &-items {
+        font-size: 0;
         @extend .abs-reset-list;
     }
 
     &-item {
-        @extend .abs-add-box-sizing;
+        font-size: 1.4rem;
         vertical-align: top;
 
         .products-grid & {
             display: inline-block;
-            width: 50%;
+            margin-left: 2%;
+            padding: 0;
+            width: calc((100% - 2%) / 2);
         }
+
+        &:nth-child(2n + 1) {
+            margin-left: 0;
+        }
+
+        @extend .abs-add-box-sizing;
 
         &-name {
             @extend .abs-product-link;
+            -moz-hyphens: auto;
+            -ms-hyphens: auto;
+            -webkit-hyphens: auto;
             display: block;
+            hyphens: auto;
             margin: $indent__xs 0;
             word-wrap: break-word;
-            hyphens: auto;
         }
 
         &-info {
@@ -38,10 +47,22 @@
         }
 
         &-actions {
-            display: none;
+            font-size: 0;
 
             .actions-secondary {
-                & > .action {
+                display: inline-block;
+                font-size: 1.4rem;
+                vertical-align: middle;
+                white-space: nowrap;
+                > button.action {
+                    @include lib-button-reset();
+                }
+
+                > .action {
+                    line-height: 35px;
+                    text-align: center;
+                    width: 35px;
+
                     @extend .abs-actions-addto-gridlist;
                     &:before {
                         margin: 0;
@@ -51,6 +72,10 @@
                         @extend .abs-visually-hidden;
                     }
                 }
+            }
+
+            .actions-primary {
+                display: inline-block;
             }
         }
 
@@ -74,7 +99,7 @@
             margin: $indent__s 0 $indent__m;
 
             .price {
-                font-size: 14px;
+                font-size: 14;
                 font-weight: $font-weight__bold;
                 white-space: nowrap;
             }
@@ -91,7 +116,7 @@
         .special-price,
         .minimal-price {
             .price {
-                font-size: 14px;
+                font-size: 14;
                 font-weight: $font-weight__bold;
             }
 
@@ -114,6 +139,12 @@
             }
         }
 
+        .regular-price {
+            .price-label {
+                display: none;
+            }
+        }
+
         .minimal-price {
             .price-container {
                 display: block;
@@ -124,8 +155,8 @@
             margin-top: 5px;
 
             .price-label {
-                color: $link__color;
-                font-size: 14px;
+                @include lib-css(color, $link__color);
+                font-size: 14;
             }
 
             .price {
@@ -145,7 +176,7 @@
             margin: 0;
         }
 
-        .action.tocompare {
+        .tocompare {
             @include lib-icon-font-symbol($icon-compare-empty);
         }
 
@@ -155,22 +186,9 @@
     }
 }
 
-.column.main {
-    .product {
-        &-items {
-            margin-left: -$indent__base;
-        }
-
-        &-item {
-            padding-left: $indent__base;
-        }
-    }
-
-}
-
 .price-container {
     .price {
-        font-size: 14px;
+        font-size: 14;
     }
 
     .price-including-tax + .price-excluding-tax,
@@ -184,7 +202,7 @@
     .weee .price,
     .weee + .price-excluding-tax:before,
     .weee + .price-excluding-tax .price {
-        font-size: 11px;
+        font-size: 11;
     }
 
     .weee {
@@ -233,6 +251,7 @@
     }
 }
 
+
 //
 //  Mobile
 //  _____________________________________________
@@ -250,53 +269,51 @@
     }
 }
 
-@include min-screen($screen__s) {
-    .product {
-        &-item {
-            .products-grid & {
-                margin-bottom: $indent__l;
-            }
-
-            &-actions {
-                display: block;
-
-                .products-grid & {
-                    margin: $indent__s 0;
-                }
-
-                .actions-primary + .actions-secondary {
-                    display: table-cell;
-                    padding-left: 5px;
-                    white-space: nowrap;
-                    width: 50%;
-                    & > * {
-                        white-space: normal;
-                    }
-                }
-
-                .actions-primary {
-                    display: table-cell;
-                }
-            }
+@include min-screen($screen__s)
+.product {
+    &-item {
+        .products-grid & {
+            margin-bottom: $indent__l;
         }
-    }
 
-    .products-grid .product-item {
-        width: 33.3333%;
-    }
+        &-actions {
+            display: block;
 
-    .page-products,
-    .page-layout-1column,
-    .page-layout-3columns,
-    .page-products.page-layout-1column,
-    .page-products.page-layout-3columns {
-        .products-grid {
-            .product-item {
-                width: 33.3333%;
+            .products-grid & {
+                margin: $indent__s 0;
+            }
+
+            .actions-primary + .actions-secondary {
+                > * {
+                    white-space: normal;
+                }
             }
         }
     }
 }
+
+.products-grid .product-item {
+    width: calc(100% / 3);
+}
+
+.page-products,
+.page-layout-1column,
+.page-layout-3columns,
+.page-products.page-layout-1column,
+.page-products.page-layout-3columns {
+    .products-grid {
+        .product-item {
+            margin-left: 2%;
+            padding: 0;
+            width: calc((100% - 4%) / 3);
+
+            &:nth-child(3n + 1) {
+                margin-left: 0;
+            }
+        }
+    }
+}
+
 
 //
 //  Desktop
@@ -306,7 +323,13 @@
     .page-products {
         .products-grid {
             .product-item {
-                width: 33.3333%;
+                margin-left: 2%;
+                padding: 0;
+                width: calc((100% - 4%) / 3);
+
+                &:nth-child(3n + 1) {
+                    margin-left: 0;
+                }
             }
         }
     }
@@ -314,7 +337,7 @@
     .page-products.page-layout-1column {
         .products-grid {
             .product-item {
-                width: 25%;
+                width: calc(100% / 4);
             }
         }
     }
@@ -322,7 +345,7 @@
     .page-products.page-layout-3columns {
         .products-grid {
             .product-item {
-                width: 50%;
+                width: calc(100% / 2);
             }
         }
     }
@@ -330,14 +353,14 @@
 @include min-screen($screen__l) {
     .products-grid {
         .product-item {
-            width: 20%;
+            width: calc(100% / 5);
         }
     }
 
     .page-layout-1column {
         .products-grid {
             .product-item {
-                width: 16.6666%;
+                width: calc(100% / 6);
             }
         }
     }
@@ -345,7 +368,7 @@
     .page-layout-3columns {
         .products-grid {
             .product-item {
-                width: 25%;
+                width: calc(100% / 4);
             }
         }
     }
@@ -357,9 +380,13 @@
             }
 
             .product-item {
-                margin-left: calc((100% - 4 * 23.233%) / 3);
+                margin-left: 2%;
                 padding: 0;
-                width: 23.233%;
+                width: calc((100% - 6%) / 4);
+
+                &:nth-child(3n + 1) {
+                    margin-left: 2%;
+                }
 
                 &:nth-child(4n + 1) {
                     margin-left: 0;
@@ -373,7 +400,7 @@
             .products-grid {
                 .product-item {
                     margin-left: 0;
-                    width: 20%;
+                    width: calc(100% / 5);
                 }
             }
         }


### PR DESCRIPTION
what a massive pain that was (and i prob should of gave up hours ago) trying to work out why rows incorrectly had three products per row and not four. I tried to cross ref the changes, but it was easier to convert the less to scss again. Turns out the calculations were outdated, regardless of how sass does or doesn't process the calc correctly (which was my initial thought)

magento/magento2@2b47de7#diff-f0f66ccc8eb7d2e0d4e821f28c6cf4663614761ecd6d47c2145dba0eb94ba5be